### PR TITLE
Add tabry bash usage description

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,8 @@ fn usage(cmd_name: Option<&str>) {
     eprintln!("  list all commands that tabry can find configs for");
     eprintln!("Usage: {} compile < file.tabry > file.json", cmd_name);
     eprintln!("  compile a tabry file to json");
+    eprintln!("Usage: {} bash", cmd_name);
+    eprintln!("  prints bash code to be eval'd to setup tabry completions");
     std::process::exit(1);
 }
 


### PR DESCRIPTION
This just adds the `tabry bash` usage description when `tabry` is run without arguments