### PR TITLE
Add nix hm module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,9 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
   outputs = { nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (
+    let
+      tabryHmModule = import ./nix/tabry-hm-module.nix;
+    in flake-utils.lib.eachDefaultSystem (
       system:
         let
           pkgs = nixpkgs.legacyPackages."${system}";
@@ -22,5 +24,9 @@
             ];
           };
         }
-    );
+    ) // {
+      homeModules = {
+        tabry = tabryHmModule;
+      };
+    };
 }

--- a/nix/Readme.md
+++ b/nix/Readme.md
@@ -1,0 +1,33 @@
+## Tabry Nix Configurations
+
+### Home Manager Module
+
+This repository provides a home-manager (https://github.com/nix-community/home-manager)
+module to make tabry easy to install and use via home manager.
+
+To use the home-manager module via flakes, add this module to your home-manager
+configuration:
+
+```nix
+{
+  inputs = {
+    tabry.url = "github:evanbattaglia/tabry-rs";
+  };
+  outputs = { ..., tabry }: {
+    homeConfigurations.<user> = {
+      modules = [
+        tabry.homeModules.tabry
+        {
+          config.programs.tabry = {
+            enable = true;
+            enableBashIntegration = true;
+            tabryFiles = [
+              ./zellij.tabry
+            ];
+          };
+        }
+      ]
+    }
+  };
+}
+```

--- a/nix/tabry-hm-module.nix
+++ b/nix/tabry-hm-module.nix
@@ -1,0 +1,65 @@
+{ config, lib, pkgs, ... }:
+
+# This file contains a Home Manager module that installs tabry
+# and sets up tabry configuration files to be used by tabry
+#
+let
+
+  cfg = config.programs.tabry;
+
+  tabry = pkgs.callPackage ../default.nix {};
+  tabryLang = pkgs.callPackage ./tabry-lang.nix { inherit tabry; };
+
+  # converts /nix/store/.../foo.tabry to "foo"
+  commandNameFromTabryFilename = fileName: 
+    (builtins.replaceStrings [".tabry"] [""] (builtins.baseNameOf fileName));
+
+  mkInitFish = fileName: let
+    commandName = commandNameFromTabryFilename fileName;
+  in ''
+    tabry_completion_init ${commandName}
+  '';
+
+  compileTabryFiles = map tabryLang.compileTabryFile;
+
+in {
+
+  options.programs.tabry = {
+    enable = lib.mkEnableOption "tabry, a tab completion library";
+    enableFishIntegration = lib.mkEnableOption "enables fish completions";
+    enableBashIntegration = lib.mkEnableOption "enables bash completions";
+    tabryFiles = lib.mkOption {
+      type = with lib.types; listOf path;
+      default = [];
+      description = ''
+        *.tabry files to be compiled to completion json
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    let
+      tabryImportsPath = builtins.concatStringsSep ":" (compileTabryFiles cfg.tabryFiles);
+    in {
+      home.packages = [tabry];
+
+      # for each file, compile it to json
+      # then add the dir to $TABRY_IMPORT_PATH
+
+      programs.fish.shellInit = lib.mkIf cfg.enableFishIntegration (
+        ''
+          set -x TABRY_IMPORT_PATH "${tabryImportsPath}:$TABRY_IMPORT_PATH"
+          ${tabry}/bin/tabry fish | source
+          ${builtins.concatStringsSep "\n" (map mkInitFish cfg.tabryFiles)}
+        ''
+      );
+
+      programs.bash.initExtra = lib.mkIf cfg.enableBashIntegration (
+        ''
+          set -x TABRY_IMPORT_PATH "${tabryImportsPath}:$TABRY_IMPORT_PATH"
+          source <(${tabry}/bin/tabry bash)
+        ''
+      );
+    }
+  );
+}

--- a/nix/tabry-lang.nix
+++ b/nix/tabry-lang.nix
@@ -1,0 +1,27 @@
+{ stdenv, tabry, ... }:
+  let
+    # converts /nix/store/.../foo.tabry to "foo"
+    commandNameFromTabryFilename = filename: 
+      (builtins.replaceStrings [".tabry"] [""] (builtins.baseNameOf filename));
+
+    formatJsonFilename = tabryFilename: 
+      (commandNameFromTabryFilename tabryFilename) + ".json";
+
+    # This is a function that takes a .tabry file
+    # and returns a derivation that compiles that
+    # .tabry file into the tabry .json file
+    compileTabryFile = inFile: stdenv.mkDerivation {
+      name = "tabry-compile-file-${inFile}";
+      buildPhase = ''
+        mkdir $out
+        ${tabry}/bin/tabry compile < ${inFile} > $out/${formatJsonFilename inFile}
+      '';
+      # by default, stdenv.mkDerivation will run `make install`
+      # which we don't want to do here
+      dontInstall = true;
+      dontUnpack = true;
+    };
+
+  in {
+    inherit compileTabryFile commandNameFromTabryFilename;
+  }


### PR DESCRIPTION
This commit adds a home-manager (https://github.com/nix-community/home-manager) module to tabry to make installation & configuration of tabry easier for home-manager users.