### PR TITLE
Add fish description support

### DIFF
--- a/docker/fish/foo.tabry
+++ b/docker/fish/foo.tabry
@@ -1,21 +1,23 @@
 cmd foo
 
-sub bar {
+sub bar "The bar command" {
   arg file {
     opts const (car motorcycle)
     opts file
   }
+  flag dry-run,d "Don't act, only show what would be done"
+  flag something-else,s "This is another flag"
 }
 
-sub baz {
-  arg directory {
+sub baz "The baz command" {
+  arg directory "a directory, yo" {
     opts const (car motorcycle)
     opts dir
     opts file
   }
 }
 
-sub qux {
+sub qux "The qux command" {
   arg directory {
     opts const (car motorcycle)
     opts dir

--- a/shell/tabry_fish.fish
+++ b/shell/tabry_fish.fish
@@ -98,7 +98,7 @@ function __tabry_offer_completions
   set cursor_position (commandline -C)
   set cmd (commandline)
 
-  set -l result ($_tabry_executable complete "$cmd" "$cursor_position")
+  set -l result ($_tabry_executable complete --include-descriptions "$cmd" "$cursor_position")
 
   # get the last item
   

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,8 +40,8 @@ enum Subcommands {
         import_path: Option<String>,
     },
 
-    /// Output completion script for bash
-    /// Usage in ~/.bash_profile: `tabry fish | source` or
+    /// Output completion script for fish
+    /// Usage in ~/.config/fish/config.fish: `tabry fish | source` or
     /// `tabry fish | source; tabry_completion_init mycmd`
     Fish {
         #[arg(long)]
@@ -67,6 +67,10 @@ enum Subcommands {
         compline: String,
         /// TODO desc
         comppoint: String,
+
+        /// Include descriptions in completions (for fish shell only)
+        #[clap(long, short, action)]
+        include_descriptions: bool,
     },
 }
 
@@ -77,13 +81,12 @@ fn main() -> Result<()> {
     use tabry::app::*;
     let cli = Cli::parse();
     match cli.command {
-        Complete { compline, comppoint } => run_as_compline(&compline, &comppoint)?,
+        Complete { compline, comppoint, include_descriptions } => run_as_compline(&compline, &comppoint, include_descriptions)?,
         Compile => compile()?,
         Commands => commands(),
         Bash { import_path, no_auto } => bash(import_path.as_deref(), no_auto),
         Zsh { import_path, no_auto } => zsh(import_path.as_deref(), no_auto),
         Fish { import_path, no_auto } => fish(import_path.as_deref(), no_auto),
     }
-
     Ok(())
 }


### PR DESCRIPTION
Fish supports "descriptions" for completions, which are displayed to the
right of the value offered for completion, to provide additional context
for the user.

To display a description for a completion, the description is printed
after a tab character in the completion line.

so, instead of just printing:
```
bar
baz
qux
```

for completions, we can print:

```
bar<TAB>The bar command
baz<TAB>The baz command
qux<TAB>The qux command
```
Which fish will display like this:
![Screenshot 2024-09-11 at 9 01 24 AM](https://github.com/user-attachments/assets/c10fcb06-e6d4-43ce-aa34-6ce4ae8a76a8)



This commit adds support for fish descriptions to tabry.

Instead of OptionsResults referencing a collection of `String`s, it now
holds a collection of `OptionResult`s, which hold the value of the
completion and an optional description.

Tabry will print a description if it is present, and if the
`TABRY_PRINT_DESCRIPTIONS` environment variable is set.