### PR TITLE
Add with tabry completion helper

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
         let
           pkgs = nixpkgs.legacyPackages."${system}";
           tabry = pkgs.callPackage ./default.nix {};
+          tabryHelpers = pkgs.callPackage ./nix/tabry-helpers.nix {};
         in {
           packages = {
             default = tabry;
@@ -23,6 +24,7 @@
               rustc
             ];
           };
+          helpers = tabryHelpers;
         }
     ) // {
       homeModules = {

--- a/nix/tabry-helpers.nix
+++ b/nix/tabry-helpers.nix
@@ -1,0 +1,36 @@
+{lib, callPackage, stdenv, installShellFiles, pkgs}:
+let 
+  tabry = pkgs.callPackage ../default.nix {};
+  tabryLang = pkgs.callPackage ./tabry-lang.nix { inherit tabry; };
+in {
+
+  withTabry =
+    tabryFile: package: 
+      let
+        cmd = builtins.replaceStrings [".tabry"] [""] (builtins.baseNameOf tabryFile);
+        compiledTabryFile = tabryLang.compileTabryFile tabryFile;
+      in stdenv.mkDerivation {
+        name = "${package.name}-with-tabry";
+        nativeBuildInputs = [ installShellFiles ];
+        src = ./.;
+        installPhase = ''
+          mkdir -p $out/bin
+          cp -R ${package}/bin $out/
+
+          ${tabry}/bin/tabry bash ${compiledTabryFile} \
+            --uniq-fn-id _NIX_${lib.toUpper package.name} >> ${cmd}.bash
+
+          installShellCompletion ${cmd}.bash
+
+          ${tabry}/bin/tabry zsh ${compiledTabryFile} \
+            --uniq-fn-id _NIX_${lib.toUpper package.name} >> ${cmd}.zsh
+
+          installShellCompletion ${cmd}.zsh
+
+          ${tabry}/bin/tabry fish ${compiledTabryFile} \
+            --uniq-fn-id _NIX_${lib.toUpper package.name} >> ${cmd}.fish
+
+          installShellCompletion ${cmd}.fish
+        '';
+      };
+}

--- a/shell/tabry_bash.sh
+++ b/shell/tabry_bash.sh
@@ -1,6 +1,6 @@
 _tabry_executable=${_tabry_executable:-$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )"/.. &> /dev/null && pwd)/target/debug/tabry}
 
-_tabry_complete_all() {
+_tabry_complete_all_UNIQ_FN_ID() {
   if [[ -z "$TABRY_IMPORT_PATH" ]]; then
     if [[ -n "$_tabry_imports_path" ]]; then
       export TABRY_IMPORT_PATH="$_tabry_imports_path"
@@ -13,20 +13,20 @@ _tabry_complete_all() {
   local oldifs="$IFS"
   IFS=$'\n'
   for cmd in $("$_tabry_executable" commands); do
-      complete -F _tabry_completions $cmd
+      complete -F _tabry_completions_UNIQ_FN_ID $cmd
   done
   IFS="$oldifs"
 }
 
-_tabry_complete_one_command() {
-  complete -F _tabry_completions $1
+_tabry_complete_one_command_UNIQ_FN_ID() {
+  complete -F _tabry_completions_UNIQ_FN_ID $1
 }
 
-_tabry_completions() {
-  _tabry_completions_internal "$_tabry_executable"
+_tabry_completions_UNIQ_FN_ID() {
+  _tabry_completions_internal_UNIQ_FN_ID "$_tabry_executable"
 }
 
-_tabry_set_compreply_from_lines() {
+_tabry_set_compreply_from_lines_UNIQ_FN_ID() {
   # Feed in lines from a variable, quoting each line.
   # Using readarray is much faster than using += many times to build the array.
   local lines="$1"
@@ -44,7 +44,7 @@ _tabry_set_compreply_from_lines() {
 }
 
 # This is unchanged from ruby tabry, except to remove the second arg
-_tabry_completions_internal()
+_tabry_completions_internal_UNIQ_FN_ID()
 {
   local tabry_bash_executable="$1"
 
@@ -65,7 +65,7 @@ _tabry_completions_internal()
     result="$(echo "$result)"|sed '/^$/q')"
 
     # First, add anything before the double newline in (regular options)
-    _tabry_set_compreply_from_lines "$result"
+    _tabry_set_compreply_from_lines_UNIQ_FN_ID "$result"
 
     while IFS= read -r specials_line; do
       if [[ "$specials_line" == "file" ]]; then
@@ -137,7 +137,7 @@ _tabry_completions_internal()
       fi
     done <<< "$specials"
   else
-    _tabry_set_compreply_from_lines "$result"
+    _tabry_set_compreply_from_lines_UNIQ_FN_ID "$result"
     COMPREPLY=()
     while IFS= read -r line; do
       COMPREPLY+=($(printf "%q" "$line"))

--- a/shell/tabry_fish.fish
+++ b/shell/tabry_fish.fish
@@ -1,24 +1,31 @@
 set -x TABRY_IMPORT_PATH "$TABRY_IMPORT_PATH:$HOME/.local/share/tabry"
 
-if not set -q _tabry_executable
+if not set -q _tabry_executable_UNIQ_FN_ID
   set script_dir (dirname (status filename))
-  set -g _tabry_executable "$script_dir/target/debug/tabry"
+  set -g _tabry_executable_UNIQ_FN_ID "$script_dir/target/debug/tabry"
 end
 
-function tabry_completion_init
+function tabry_completion_init_UNIQ_FN_ID
   set cmd $argv[1]
-  complete -c "$cmd" -f -a "(__tabry_offer_completions)"
+  complete -c "$cmd" -f -a "(__tabry_offer_completions_UNIQ_FN_ID)"
+end
+
+# Init completions for all commands in the path
+function tabry_completion_init_all_UNIQ_FN_ID
+  for cmd in ($_tabry_executable_UNIQ_FN_ID commands)
+    tabry_completion_init_UNIQ_FN_ID $cmd
+  end
 end
 
 # Init completions for all commands in the path
 function tabry_completion_init_all
   for cmd in (tabry commands)
-    tabry_completion_init $cmd
+    tabry_completion_init_UNIQ_FN_ID $cmd
   end
 end
 
 # parse the results from tabry
-function __tabry_parse_results
+function __tabry_parse_results_UNIQ_FN_ID
   # take from $result until two newlines
   set -l completions
   set -l done_completions "false"
@@ -43,9 +50,9 @@ function __tabry_parse_results
   end
 
   if test "$offer_dirs" = "true"
-    __fish_complete_directories (__tabry_get_token_on_cursor $cmd $cursor_position)
+    __fish_complete_directories (__tabry_get_token_on_cursor_UNIQ_FN_ID $cmd $cursor_position)
   else if test "$offer_files" = "true"
-    __fish_complete_path (__tabry_get_token_on_cursor $cmd $cursor_position)
+    __fish_complete_path (__tabry_get_token_on_cursor_UNIQ_FN_ID $cmd $cursor_position)
   end
 end
 
@@ -63,7 +70,7 @@ end
 # foo  bar baz
 #         ^ cursor_position
 # returns "bar"
-function __tabry_get_token_on_cursor
+function __tabry_get_token_on_cursor_UNIQ_FN_ID
   set -l cmd $argv[1]
   set -l cursor_position (math $argv[2] + 1) # fish is 1-indexed
 
@@ -90,7 +97,7 @@ function __tabry_get_token_on_cursor
   echo "$token"
 end
 
-function __tabry_offer_completions
+function __tabry_offer_completions_UNIQ_FN_ID
   set SCRIPT (status --current-filename)
   set SCRIPT_DIR (dirname $SCRIPT)
 
@@ -98,11 +105,11 @@ function __tabry_offer_completions
   set cursor_position (commandline -C)
   set cmd (commandline)
 
-  set -l result ($_tabry_executable complete --include-descriptions "$cmd" "$cursor_position")
+  set -l result ($_tabry_executable_UNIQ_FN_ID complete --include-descriptions "$cmd" "$cursor_position")
 
   # get the last item
   
   # if result ends with "\n\nfile", then we should offer files
   # if result ends with "\n\ndir", then we should offer directories
-  __tabry_parse_results $result
+  __tabry_parse_results_UNIQ_FN_ID $result
 end

--- a/shell/tabry_zsh.sh
+++ b/shell/tabry_zsh.sh
@@ -6,7 +6,7 @@ autoload -U +X bashcompinit && bashcompinit
 
 _tabry_executable=${_tabry_executable:-$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )"/.. &> /dev/null && pwd)/target/debug/tabry}
 
-_tabry_complete_all() {
+_tabry_complete_all_UNIQ_FN_ID() {
   if [[ -z "$TABRY_IMPORT_PATH" ]]; then
     if [[ -n "$_tabry_imports_path" ]]; then
       export TABRY_IMPORT_PATH="$_tabry_imports_path"
@@ -19,20 +19,20 @@ _tabry_complete_all() {
   local oldifs="$IFS"
   IFS=$'\n'
   for cmd in $("$_tabry_executable" commands); do
-      complete -F _tabry_completions $cmd
+      complete -F _tabry_completions_UNIQ_FN_ID $cmd
   done
   IFS="$oldifs"
 }
 
-_tabry_complete_one_command() {
-  complete -F _tabry_completions $1
+_tabry_complete_one_command_UNIQ_FN_ID() {
+  complete -F _tabry_completions_UNIQ_FN_ID $1
 }
 
-_tabry_completions() {
-  _tabry_completions_internal "$_tabry_executable"
+_tabry_completions_UNIQ_FN_ID() {
+  _tabry_completions_internal_UNIQ_FN_ID "$_tabry_executable"
 }
 
-_tabry_set_compreply_from_lines() {
+_tabry_set_compreply_from_lines_UNIQ_FN_ID() {
   # Feed in lines from a variable, quoting each line.
   # Using readarray is much faster than using += many times to build the array.
   local lines="$1"
@@ -50,7 +50,7 @@ _tabry_set_compreply_from_lines() {
 }
 
 # This is unchanged from ruby tabry, except to remove the second arg
-_tabry_completions_internal()
+_tabry_completions_internal_UNIQ_FN_ID()
 {
   local tabry_bash_executable="$1"
 
@@ -71,7 +71,7 @@ _tabry_completions_internal()
     result="$(echo "$result)"|sed '/^$/q')"
 
     # First, add anything before the double newline in (regular options)
-    _tabry_set_compreply_from_lines "$result"
+    _tabry_set_compreply_from_lines_UNIQ_FN_ID "$result"
 
     while IFS= read -r specials_line; do
       if [[ "$specials_line" == "file" ]]; then
@@ -144,7 +144,7 @@ _tabry_completions_internal()
       fi
     done <<< "$specials"
   else
-    _tabry_set_compreply_from_lines "$result"
+    _tabry_set_compreply_from_lines_UNIQ_FN_ID "$result"
     COMPREPLY=()
     while IFS= read -r line; do
       COMPREPLY+=($(printf "%q" "$line"))

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -106,43 +106,49 @@ fn escaped_exe() -> String {
 }
 
 const TABRY_BASH_SH: &str = include_str!("../../shell/tabry_bash.sh");
-pub fn bash(imports_path: Option<&str>, no_auto: bool) {
+pub fn bash(imports_path: Option<&str>, no_auto: bool, uniq_fn_id: Option<&str>) {
     if let Some(path) = imports_path {
         println!("_tabry_imports_path={}", escape(path));
     }
+    let fn_id: &str = uniq_fn_id.unwrap_or("");
     println!("_tabry_executable={}", escaped_exe());
-    print!("{}", TABRY_BASH_SH);
+
+    print!("{}", TABRY_BASH_SH.replace("_UNIQ_FN_ID", fn_id));
 
     if !no_auto {
         // TODO name things consistently between fish + bash
-        println!("_tabry_complete_all");
+        println!("_tabry_complete_all{}", fn_id);
     }
 }
 
 const TABRY_ZSH_SH: &str = include_str!("../../shell/tabry_zsh.sh");
-pub fn zsh(imports_path: Option<&str>, no_auto: bool) {
+pub fn zsh(imports_path: Option<&str>, no_auto: bool, uniq_fn_id: Option<&str>) {
     if let Some(path) = imports_path {
         println!("_tabry_imports_path={}", escape(path));
     }
+    let fn_id: &str = uniq_fn_id.unwrap_or("");
     println!("_tabry_executable={}", escaped_exe());
-    print!("{}", TABRY_ZSH_SH);
+    print!("{}", TABRY_ZSH_SH.replace("_UNIQ_FN_ID", fn_id));
 
     if !no_auto {
         // TODO name things consistently between fish + zsh
-        println!("_tabry_complete_all");
+        println!("_tabry_complete_all{}", fn_id);
     }
 }
 
 const TABRY_FISH_SH: &str = include_str!("../../shell/tabry_fish.fish");
-pub fn fish(imports_path: Option<&str>, no_auto: bool) {
+pub fn fish(imports_path: Option<&str>, no_auto: bool, uniq_fn_id: Option<&str>) {
     if let Some(path) = imports_path {
         println!("set -x TABRY_IMPORT_PATH {}", escape(path));
     }
 
-    println!("set -x _tabry_executable {}", escaped_exe());
-    print!("{}", TABRY_FISH_SH);
+    let fn_id: &str = uniq_fn_id.unwrap_or("");
+
+    println!("set -x _tabry_executable{} {}", fn_id, escaped_exe());
+
+    print!("{}", TABRY_FISH_SH.replace("_UNIQ_FN_ID", fn_id));
 
     if !no_auto {
-        println!("tabry_completion_init_all");
+        println!("tabry_completion_init_all{}", fn_id);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,10 @@ enum Subcommands {
         #[arg(index = 1)]
         /// Import path (colon-separated)
         import_path: Option<String>,
+
+        #[arg(long)]
+        /// Unique function ID (useful for making sure multiple tabry versions don't conflict)
+        uniq_fn_id: Option<String>,
     },
 
     /// Output completion script for zsh
@@ -38,6 +42,10 @@ enum Subcommands {
         #[arg(index = 1)]
         /// Import path (colon-separated)
         import_path: Option<String>,
+
+        #[arg(long)]
+        /// Unique function ID (useful for making sure multiple tabry versions don't conflict)
+        uniq_fn_id: Option<String>,
     },
 
     /// Output completion script for fish
@@ -52,6 +60,10 @@ enum Subcommands {
         #[arg(index = 1)]
         /// Import path (colon-separated)
         import_path: Option<String>,
+
+        #[arg(long)]
+        /// Unique function ID (useful for making sure multiple tabry versions don't conflict)
+        uniq_fn_id: Option<String>,
     },
 
     /// List commands for which there is a .tabry/.json file in TABRY_IMPORT_PATH
@@ -91,15 +103,18 @@ fn main() -> Result<()> {
         Bash {
             import_path,
             no_auto,
-        } => bash(import_path.as_deref(), no_auto),
+            uniq_fn_id
+        } => bash(import_path.as_deref(), no_auto, uniq_fn_id.as_deref()),
         Zsh {
             import_path,
             no_auto,
-        } => zsh(import_path.as_deref(), no_auto),
+            uniq_fn_id
+        } => zsh(import_path.as_deref(), no_auto, uniq_fn_id.as_deref()),
         Fish {
             import_path,
             no_auto,
-        } => fish(import_path.as_deref(), no_auto),
+            uniq_fn_id
+        } => fish(import_path.as_deref(), no_auto, uniq_fn_id.as_deref()),
     }
     Ok(())
 }


### PR DESCRIPTION
This commit adds a nix helper for binding tabry completion files with
nix packages. The `withTabry` function is a nix function that takes a
tabry completion file and a nix package and returns a derivation that
installs the completion file in the package's completion directory.

example usage:

```nix
wrappedCommand = withTabry ./command.tabry <pkg>
```