### PR TITLE
Add clippy to devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
               rustfmt
               cargo
               rustc
+              clippy
             ];
           };
         }


### PR DESCRIPTION
This commit adds clippy to the devshell so users can run clippy locally with nix without installing it globally